### PR TITLE
Generate per-endpoint candidates

### DIFF
--- a/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/README.md
+++ b/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/README.md
@@ -13,11 +13,14 @@ Run:
 ```
 python preprocess.py 
 ```
-This will identify candidate identifiers and strings that will LIKELY (99.9% chance) return API results. Takes a few minutes. 
+This will identify candidate identifiers and strings that will LIKELY (99.9% chance) return API results.
+The script now saves a list of candidate atoms **per endpoint** in `subset/valid_codes.json`.
+Each test in `test.py` uses its own list of examples. Processing takes a few minutes.
 
 ## Run tests
 
-test.py will choose random examples from the preprocessed subset to test against the API. The examples will be different every time you test. 
+test.py will choose random examples from each endpoint's preprocessed subset to test
+against the API. The examples will be different every time you test.
 
 Run
 ```

--- a/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/preprocess.py
+++ b/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/preprocess.py
@@ -17,6 +17,34 @@ MRSAT_PATH   = INPUT_DIR / "MRSAT.RRF"
 MRCONSO_PATH = INPUT_DIR / "MRCONSO.RRF"
 OUTPUT_FILE  = OUTPUT_DIR  / "valid_codes.json"
 
+# Endpoint names from test.py. Each will get its own list of candidate atoms.
+ENDPOINT_NAMES = [
+    "Search - basic",
+    "Search - basic - high page size",
+    "Search - exact",
+    "Search - return a CODE",
+    "Search - input CODE, return CUIs",
+    "Search - input CUI, return CODE",
+    "Search - left truncation",
+    "Search - right truncation",
+    "Search - normalized string",
+    "Search - normalized words",
+    "Concept",
+    "Concept Atoms",
+    "Concept Definitions",
+    "Concept Relations",
+    "Code",
+    "Code Attributes",
+    "Code Children",
+    "Code Parents",
+    "Code Ancestors",
+    "Code Descendants",
+    "Code Relations",
+    "Code Atoms",
+    "Code Default Preferred Atom",
+    "Code Crosswalk",
+]
+
 # ---- Step 1: Extract CUIs with Definitions ----
 def extract_cuis_with_definitions(def_path):
     cuis = set()
@@ -120,8 +148,12 @@ def main():
     print(f"✔️  Valid atoms extracted: {len(atoms):,}")
 
     print(f"💾 Saving results to {OUTPUT_FILE}...")
+    # Store a separate list of candidate atoms for each endpoint. Currently
+    # the same atom list works for all endpoints, but separating them makes it
+    # easy to further customize in the future.
+    data = {name: atoms for name in ENDPOINT_NAMES}
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
-        json.dump(atoms, f, indent=2)
+        json.dump(data, f, indent=2)
 
     print(f"\n⏱️ Completed in {time.time() - start:.2f} seconds")
 

--- a/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/test.py
+++ b/src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/test.py
@@ -31,11 +31,12 @@ if not VALID_CODES_PATH.exists():
     sys.exit(1)
 
 with open(VALID_CODES_PATH, "r", encoding="utf-8") as f:
-    atoms = json.load(f)
-if not atoms:
+    atoms_by_endpoint = json.load(f)
+if not atoms_by_endpoint:
     print("❌ No usable atoms found in valid_codes.json.")
     sys.exit(1)
-print(f"🧠 Loaded {len(atoms):,} prefiltered atoms from {VALID_CODES_PATH.name}")
+total_atoms = sum(len(v) for v in atoms_by_endpoint.values())
+print(f"🧠 Loaded {total_atoms:,} prefiltered atoms across {len(atoms_by_endpoint)} endpoints from {VALID_CODES_PATH.name}")
 
 VERSION = "current"
 ENDPOINTS = {
@@ -80,9 +81,13 @@ metrics = defaultdict(lambda: {"times": [], "failures": 0})
 # ---- Regular Requests ----
 for name, path_fn in ENDPOINTS.items():
     print(f"\n📊 Benchmarking: {name}")
+    candidates = atoms_by_endpoint.get(name)
+    if not candidates:
+        print(f"⚠️  No candidate atoms available for {name}; skipping")
+        continue
     start_time = time.time()
     for _ in range(NUM_TRIALS):
-        atom = random.choice(atoms)
+        atom = random.choice(candidates)
         path = path_fn(atom)
         full_url = f"{BASE_URL}{path}&apiKey={args.apiKey}" if "?" in path else f"{BASE_URL}{path}?apiKey={args.apiKey}"
         try:


### PR DESCRIPTION
## Summary
- tweak README text for per-endpoint candidate lists
- provide endpoint names in `preprocess.py`
- save a candidate list for each endpoint
- update `test.py` to read per-endpoint candidates

## Testing
- `python -m py_compile src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/preprocess.py src/gov/nih/nlm/lo/umls/uts/documentation/api-tests/test.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7c8aca7c832792ed51a4b57e241c